### PR TITLE
Fix/action go no verb

### DIFF
--- a/Language_Parser/languageParser.py
+++ b/Language_Parser/languageParser.py
@@ -92,5 +92,7 @@ def parse(userText, player, game):
             globals()[parsedInput["Verb"][0]](parsedInput)
         except KeyError:
             print("I'm sorry, I don't understand that command.")
+    elif len(parsedInput["Verb"]) == 0 and len(parsedInput["Rooms"]) > 0:
+        go(parsedInput)
     else:
         print("I'm sorry, I don't understand that command.")


### PR DESCRIPTION
Update to allow movement without directly including the 'go' command in user input. If no verb is included in a command, and a room/direction is included, then go will be the assumed verb. For example, entering 'east' will now behave the same as 'go east'.