### PR TITLE
Quick fixes

### DIFF
--- a/Language_Parser/compoundWords.json
+++ b/Language_Parser/compoundWords.json
@@ -24,5 +24,7 @@
   "coat": "rack",
   "tool": "bag",
   "garage": "door",
-  "book": "case"
+  "book": "case",
+  "pile": "of",
+  "pileof": "cans"
 }

--- a/Language_Parser/itemDictionary.json
+++ b/Language_Parser/itemDictionary.json
@@ -8,7 +8,7 @@
     "bushes": ["bushes", "bush"],
     "cabinet": ["cabinet", "medicinecabinet", "cabinets"],
     "canOpener": ["canopener"],
-    "canPile": ["cans", "pileofcans"],
+    "canPile": ["cans", "pileofcans", "pile"],
     "catFood": ["catfood"],
     "closet": ["closet"],
     "clothes": ["clothes"],

--- a/Rooms/familyRoom.json
+++ b/Rooms/familyRoom.json
@@ -23,7 +23,7 @@
             "rack": "It's just a simple metal pole. Your jacket is hanging from it.",
             "jacket": "It's mostly fake leather. There is nothing in the pockets.",
             "hooks": "There are four hooks screwed into the wall. One of them is holding a key.",
-            "key": "You glance through the moving boxes, but there's nothing useful in here."
+            "key": "It's a tarnished brass key. What could this be for?"
         },
         "Take": {
             "key": "You take the key from its hook."


### PR DESCRIPTION
languageParser will now interpret "pile of cans" by doing the following:

"pile of" will become "pileof"
then, "pileof cans" will become "pileofcans"