### PR TITLE
Changing item visibility in Rooms

### DIFF
--- a/Classes/game.py
+++ b/Classes/game.py
@@ -279,19 +279,33 @@ class Game:
         with open("Items/defaultLocations.json") as f:
             itemDict = json.load(f)
         f.close()
-        for key, value in itemDict.items():
-            itemName = key + ".json"
-            file = os.path.join("Items", itemName)
-            if type(value) == list:
+
+        # Open the item's file
+        for itemName, value in itemDict.items():
+            itemPath = itemName + ".json"
+            file = os.path.join("Items", itemPath)
+
+            # Set location and visibility
+            location = value["location"]
+            visible = False
+            if value["visible"].lower() == "true":
+                visible = True
+
+            # Place the items
+            if type(location) == list:
                 item = Item(file)
                 for room in self.rooms:
-                    if room == value[0]:
-                        room.addItem(item)
-                value = value[1]
+                    if room == location[0] and visible:
+                        room.addVisibleItem(item)
+                    elif room == location[0] and not visible:
+                        room.addHiddenItem(item)
+                location = location[1]
             item = Item(file)
             for room in self.rooms:
-                if room == value:
-                    room.addItem(item)
+                if room == location and visible:
+                    room.addVisibleItem(item)
+                elif room == location and not visible:
+                    room.addHiddenItem(item)
 
     def setStartRoom(self):
         """

--- a/Classes/room.py
+++ b/Classes/room.py
@@ -212,13 +212,13 @@ class Room:
         Removes a dropped item from the room.
         This should be used when the player "picks up" a dropped item.
         Input "itemName" should be an item's name string.
-        Returns the item if removed, or 1 if item wasn't found.
+        Returns the item if removed, or None if item wasn't found.
         """
         for item in self.droppedItems:
             if item.name == itemName:
                 self.droppedItems.remove(item)
                 return item
-        return 1
+        return None
 
     def getDroppedItems(self):
         """
@@ -239,13 +239,13 @@ class Room:
         """
         Removes a hidden item from the room.
         Input "itemName" should be an item's name string.
-        Returns the item if removed, or 1 if item wasn't found.
+        Returns the item if removed, or None if item wasn't found.
         """
         for item in self.hiddenItems:
             if item.name == itemName:
                 self.hiddenItems.remove(item)
                 return item
-        return 1
+        return None
 
     def getHiddenItems(self):
         """
@@ -264,13 +264,13 @@ class Room:
         """
         Removes a visible item from the room.
         Input "itemName" should be an item's name string.
-        Returns the item if removed, or 1 if item wasn't found.
+        Returns the item if removed, or None if item wasn't found.
         """
         for item in self.visibleItems:
             if item.name == itemName:
                 self.visibleItems.remove(item)
                 return item
-        return 1
+        return None
 
     def getVisibleItems(self):
         """
@@ -312,15 +312,15 @@ class Room:
         Removes a visible item from the room.
         This can be used for moving an item from the room to the inventory.
         Input "itemName" should be an item's name string.
-        Returns the item if removed, or 1 if item wasn't found.
+        Returns the item if removed, or None if item wasn't found.
         """
         # Check visible items
         result = self.removeVisibleItem(itemName)
-        if result == 1:
+        if result is None:
             result = self.removeDroppedItem(itemName)
-            if result == 1:
-                # If it's on neither list, return 1
-                return 1
+            if result is None:
+                # If it's on neither list, return None
+                return None
         return result
 
     def verbResponses(self, verb, feature):
@@ -334,8 +334,6 @@ class Room:
         except KeyError:
             pass
         return response
-
-    # TODO: Add method for applicable verb actions?
 
     # TODO: The following two functions can be removed later, if desired.
 

--- a/Classes/room.py
+++ b/Classes/room.py
@@ -125,8 +125,7 @@ class Room:
 
     def getItemDescriptions(self):
         """
-        This function will describe any items dropped in the room
-        which do not normally belong here.
+        This function will describe any items dropped in the room.
         """
         tempStr = " You left the "
 
@@ -136,8 +135,6 @@ class Room:
             # Add a comma & space between additional items
             if index != len(self.droppedItems) - 1:
                 tempStr = tempStr + ", "
-
-        tempStr = tempStr + " here."
 
         tempStr = tempStr + " here."
 

--- a/Classes/room.py
+++ b/Classes/room.py
@@ -44,8 +44,17 @@ class Room:
         for key, val in data["exits"].items():
             self.exits[key] = val
 
-        # Items are populated by the Game class
-        self.items = []
+        # Dropped Items are things dropped by the player during gameplay,
+        # whether the item originally belonged in the room or not.
+        self.droppedItems = []
+
+        # Unlocked Items belong in the room by default,
+        # but are VISIBLE and ACCESSIBLE to the player.
+        self.visibleItems = []
+
+        # Hidden Items belong in the room by default,
+        # but they are INVISIBLE and INACCESSIBLE to the player.
+        self.hiddenItems = []
 
         file.close()
 
@@ -74,11 +83,11 @@ class Room:
 
         # Adds any conditional statements
         if self.conditions:
-            desc = desc + " " + self.getConditionalDesc()
+            desc = desc + self.getConditionalDesc()
 
         # Describe any items that were left here by the player
-        # if self.items:
-        #     desc = desc + self.getItemDescriptions()
+        if self.droppedItems:
+            desc = desc + self.getItemDescriptions()
 
         return textwrap.fill(desc, fill_width)
 
@@ -94,8 +103,8 @@ class Room:
             desc = desc + self.getConditionalDesc()
 
         # Describe any items that were left here by the player
-        # if self.items:
-        #     desc = desc + self.getItemDescriptions()
+        if self.droppedItems:
+            desc = desc + self.getItemDescriptions()
 
         return desc
 
@@ -120,21 +129,15 @@ class Room:
         which do not normally belong here.
         """
         tempStr = " You left the "
-        tempItems = self.items.copy()
 
-        # Do not describe items that DO belong in this room by default
-        for item in tempItems:
-            for condition in self.conditions:
-                if item.name == condition.name:
-                    tempItems.remove(item)
-
-        # Describe the ones that DON'T belong
-        for index, item in enumerate(tempItems):
+        for index, item in enumerate(self.droppedItems):
             tempStr = tempStr + item.name
 
             # Add a comma & space between additional items
-            if index != len(tempItems) - 1:
+            if index != len(self.droppedItems) - 1:
                 tempStr = tempStr + ", "
+
+        tempStr = tempStr + " here."
 
         tempStr = tempStr + " here."
 
@@ -199,27 +202,129 @@ class Room:
                 return True
         return False
 
-    def addItem(self, item):
+    def addDroppedItem(self, item):
         """
-        Adds an item to the room - items will be instances of Item class
+        Adds a dropped item to the room.
+        This should be used when the player "drops" items.
+        Input "item" should be Item object.
         """
-        self.items.append(item)
+        self.droppedItems.append(item)
 
-    def removeItem(self, itemName):
+    def removeDroppedItem(self, itemName):
         """
-        Removes an item from the room - items are instances of Item class
+        Removes a dropped item from the room.
+        This should be used when the player "picks up" a dropped item.
+        Input "itemName" should be an item's name string.
+        Returns the item if removed, or 1 if item wasn't found.
         """
-        for item in self.items:
+        for item in self.droppedItems:
             if item.name == itemName:
-                self.items.remove(item)
+                self.droppedItems.remove(item)
                 return item
-        return None
+        return 1
 
-    def getItems(self):
+    def getDroppedItems(self):
         """
-        Returns the list of items in the room
+        Returns the list of items dropped in the room.
+        Does NOT include items which are in their default locations.
         """
-        return self.items
+        return self.droppedItems
+
+    def addHiddenItem(self, item):
+        """
+        Adds a hidden item to the room.
+        This should be used when the Game class builds the items.
+        Input "item" should be Item object.
+        """
+        self.hiddenItems.append(item)
+
+    def removeHiddenItem(self, itemName):
+        """
+        Removes a hidden item from the room.
+        Input "itemName" should be an item's name string.
+        Returns the item if removed, or 1 if item wasn't found.
+        """
+        for item in self.hiddenItems:
+            if item.name == itemName:
+                self.hiddenItems.remove(item)
+                return item
+        return 1
+
+    def getHiddenItems(self):
+        """
+        Returns the list of hidden items in the room.
+        """
+        return self.hiddenItems
+
+    def addVisibleItem(self, item):
+        """
+        Adds a visible item to the room.
+        Input "item" should be Item object.
+        """
+        self.visibleItems.append(item)
+
+    def removeVisibleItem(self, itemName):
+        """
+        Removes a visible item from the room.
+        Input "itemName" should be an item's name string.
+        Returns the item if removed, or 1 if item wasn't found.
+        """
+        for item in self.visibleItems:
+            if item.name == itemName:
+                self.visibleItems.remove(item)
+                return item
+        return 1
+
+    def getVisibleItems(self):
+        """
+        Returns the list of visible items in the room.
+        """
+        return self.visibleItems
+
+    def unlockItem(self, itemName):
+        """
+        Switches an item from hidden to visible.
+        Input "itemName" should be an item's name string.
+        """
+        for item in self.hiddenItems:
+            if item.name == itemName:
+                self.addVisibleItem(item)
+                self.removeHiddenItem(item)
+
+    def isItemLocked(self, itemName):
+        """
+        Returns boolean for whether an item is accessible by the player or not.
+        Input "itemName" should be an item's name string.
+        """
+        for item in self.getAccessibleItems():
+            if item.name == itemName:
+                return False
+            else:
+                return True
+
+    def getAccessibleItems(self):
+        """
+        Returns the list of all items in the room which are
+        visible and accessible to the player. Includes both
+        dropped and visible room items.
+        """
+        return self.droppedItems + self.visibleItems
+
+    def removeAccessibleItem(self, itemName):
+        """
+        Removes a visible item from the room.
+        This can be used for moving an item from the room to the inventory.
+        Input "itemName" should be an item's name string.
+        Returns the item if removed, or 1 if item wasn't found.
+        """
+        # Check visible items
+        result = self.removeVisibleItem(itemName)
+        if result == 1:
+            result = self.removeDroppedItem(itemName)
+            if result == 1:
+                # If it's on neither list, return 1
+                return 1
+        return result
 
     def verbResponses(self, verb, feature):
         """
@@ -264,12 +369,30 @@ class Room:
         """
         Prints room details for easier debugging
         """
+        dropItems = ""
+        hidItems = ""
+        visItems = ""
+
+        if self.droppedItems:
+            for d in self.droppedItems:
+                dropItems = dropItems + d.name + ", "
+
+        if self.hiddenItems:
+            for h in self.hiddenItems:
+                hidItems = hidItems + h.name + ", "
+
+        if self.visibleItems:
+            for v in self.visibleItems:
+                visItems = visItems + v.name + ", "
+
         print(f"######## Room name: {self.name} ########\n"
               f"- Locked? {self.locked}\n"
               f"- Visited? {self.visited}\n"
               f"- Long description:\n{self.getLongDescription()}\n"
               f"- Short description:\n{self.getShortDescription()}\n"
               f"- Exits: {self.exits}\n"
-              f"- Items: {self.items}\n"
+              f"- Hidden items: {hidItems[:-2]}\n"
+              f"- Visible items: {visItems[:-2]}\n"
+              f"- Dropped items: {dropItems[:-2]}\n"
               f"- Conditionals:\n{self.printConditionalsTest()}")
         print("")

--- a/Items/defaultLocations.json
+++ b/Items/defaultLocations.json
@@ -1,12 +1,42 @@
 {
-  "ladder": "garage",
-  "flashlight": "utilityRoom",
-  "battery": ["masterBedroom", "secondBedroom"],
-  "key": "familyRoom",
-  "canOpener": "kitchen",
-  "tinCan": "basement",
-  "silverBell": "diningRoom",
-  "polaroid1": "upperHall",
-  "polaroid2": "kitchen",
-  "polaroid3": "attic"
+    "ladder": {
+        "location": "garage",
+        "visible": "True"
+    },
+    "flashlight": {
+        "location": "utilityRoom",
+        "visible": "False"
+    },
+    "battery": {
+        "location": ["masterBedroom", "secondBedroom"],
+        "visible": "False"
+    },
+    "key": {
+        "location": "familyRoom",
+        "visible": "False"
+    },
+    "canOpener": {
+        "location": "kitchen",
+        "visible": "False"
+    },
+    "tinCan": {
+        "location": "basement",
+        "visible": "True"
+    },
+    "silverBell": {
+        "location": "diningRoom",
+        "visible": "False"
+    },
+    "polaroid1": {
+        "location": "upperHall",
+        "visible": "False"
+    },
+    "polaroid2": {
+        "location": "kitchen",
+        "visible": "False"
+    },
+    "polaroid3": {
+        "location": "attic",
+        "visible": "False"
+    }
 }


### PR DESCRIPTION
Adding separate categories in Rooms for "hidden", "visible", and "dropped" items.

"Hidden" items belong in the room by default but should not be revealed or accessible to the player (not yet picked up).
"Visible" items belong in the room by default but are visible and accessible to the player (not yet picked up).
"Dropped" items are dropped by the player (after being picked up).

There's also a method to return all "accessible" items, which includes both "visible" and "dropped" items.